### PR TITLE
Fix username field path changes

### DIFF
--- a/src/components/table/columns-tweet.tsx
+++ b/src/components/table/columns-tweet.tsx
@@ -141,26 +141,40 @@ export const columns = [
       />
     ),
   }),
-  columnHelper.accessor('core.user_results.result.legacy.screen_name', {
-    meta: { exportKey: 'screen_name', exportHeader: 'Screen Name' },
-    header: () => <Trans i18nKey="Screen Name" />,
-    cell: (info) => (
-      <p class="whitespace-pre">
-        <a
-          class="link"
-          target="_blank"
-          href={getUserURL(info.row.original.core.user_results.result)}
-        >
-          @{info.getValue()}
-        </a>
-      </p>
-    ),
-  }),
-  columnHelper.accessor('core.user_results.result.legacy.name', {
-    meta: { exportKey: 'name', exportHeader: 'Profile Name' },
-    header: () => <Trans i18nKey="Profile Name" />,
-    cell: (info) => <p class="w-32">{info.getValue()}</p>,
-  }),
+  columnHelper.accessor(
+    (row) =>
+      row.core.user_results.result.legacy?.screen_name ??
+      row.core.user_results.result.core?.screen_name ??
+      '',
+    {
+      id: 'screen_name',
+      meta: { exportKey: 'screen_name', exportHeader: 'Screen Name' },
+      header: () => <Trans i18nKey="Screen Name" />,
+      cell: (info) => (
+        <p class="whitespace-pre">
+          <a
+            class="link"
+            target="_blank"
+            href={getUserURL(info.row.original.core.user_results.result)}
+          >
+            @{info.getValue()}
+          </a>
+        </p>
+      ),
+    },
+  ),
+  columnHelper.accessor(
+    (row) =>
+      row.core.user_results.result.legacy?.name ??
+      row.core.user_results.result.core?.name ??
+      '',
+    {
+      id: 'name',
+      meta: { exportKey: 'name', exportHeader: 'Profile Name' },
+      header: () => <Trans i18nKey="Profile Name" />,
+      cell: (info) => <p class="w-32">{info.getValue()}</p>,
+    },
+  ),
   columnHelper.accessor('core.user_results.result.legacy.profile_image_url_https', {
     meta: { exportKey: 'profile_image_url', exportHeader: 'Profile Image' },
     header: () => <Trans i18nKey="Profile Image" />,

--- a/src/components/table/columns-user.tsx
+++ b/src/components/table/columns-user.tsx
@@ -45,22 +45,30 @@ export const columns = [
     header: () => <Trans i18nKey="ID" />,
     cell: (info) => <p class="w-20 break-all font-mono text-xs">{info.getValue()}</p>,
   }),
-  columnHelper.accessor('legacy.screen_name', {
-    meta: { exportKey: 'screen_name', exportHeader: 'Screen Name' },
-    header: () => <Trans i18nKey="Screen Name" />,
-    cell: (info) => (
-      <p class="whitespace-pre">
-        <a class="link" target="_blank" href={getUserURL(info.row.original)}>
-          @{info.getValue()}
-        </a>
-      </p>
-    ),
-  }),
-  columnHelper.accessor('legacy.name', {
-    meta: { exportKey: 'name', exportHeader: 'Profile Name' },
-    header: () => <Trans i18nKey="Profile Name" />,
-    cell: (info) => <p class="w-32">{info.getValue()}</p>,
-  }),
+  columnHelper.accessor(
+    (row) => row.legacy.screen_name ?? row.core?.screen_name ?? '',
+    {
+      id: 'screen_name',
+      meta: { exportKey: 'screen_name', exportHeader: 'Screen Name' },
+      header: () => <Trans i18nKey="Screen Name" />,
+      cell: (info) => (
+        <p class="whitespace-pre">
+          <a class="link" target="_blank" href={getUserURL(info.row.original)}>
+            @{info.getValue()}
+          </a>
+        </p>
+      ),
+    },
+  ),
+  columnHelper.accessor(
+    (row) => row.legacy.name ?? row.core?.name ?? '',
+    {
+      id: 'name',
+      meta: { exportKey: 'name', exportHeader: 'Profile Name' },
+      header: () => <Trans i18nKey="Profile Name" />,
+      cell: (info) => <p class="w-32">{info.getValue()}</p>,
+    },
+  ),
   columnHelper.accessor('legacy.description', {
     meta: { exportKey: 'description', exportHeader: 'Description' },
     header: () => <Trans i18nKey="Description" />,

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -23,6 +23,15 @@ export interface User {
   has_graduated_access: boolean;
   is_blue_verified: boolean;
   profile_image_shape: 'Square' | 'Circle';
+  /**
+   * New location of some basic profile fields since a Twitter update.
+   * These fields used to be in the `legacy` object.
+   */
+  core?: {
+    created_at?: string;
+    name?: string;
+    screen_name?: string;
+  };
   legacy: {
     followed_by: boolean;
     following: boolean;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -237,7 +237,8 @@ export function extractQuotedTweet(tweet: Tweet): Tweet | null {
 }
 
 export function extractTweetUserScreenName(tweet: Tweet): string {
-  return tweet.core.user_results.result.legacy.screen_name;
+  const user = tweet.core.user_results.result;
+  return user.legacy?.screen_name ?? user.core?.screen_name ?? '';
 }
 
 export function extractTweetMedia(tweet: Tweet): Media[] {
@@ -355,7 +356,10 @@ export function getTweetURL(tweet: Tweet): string {
 }
 
 export function getUserURL(user: User | string): string {
-  return `https://twitter.com/${typeof user === 'string' ? user : user.legacy.screen_name}`;
+  if (typeof user === 'string') {
+    return `https://twitter.com/${user}`;
+  }
+  return `https://twitter.com/${user.legacy?.screen_name ?? user.core?.screen_name ?? ''}`;
 }
 
 export function getInReplyToTweetURL(tweet: Tweet): string {

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -21,11 +21,17 @@ export const patterns: Record<string, { description: string; extractor: PatternE
   },
   screen_name: {
     description: 'The username of tweet author',
-    extractor: (tweet) => tweet.core.user_results.result.legacy.screen_name,
+    extractor: (tweet) =>
+      tweet.core.user_results.result.legacy?.screen_name ??
+      tweet.core.user_results.result.core?.screen_name ??
+      '',
   },
   name: {
     description: 'The profile name of tweet author',
-    extractor: (tweet) => tweet.core.user_results.result.legacy.name,
+    extractor: (tweet) =>
+      tweet.core.user_results.result.legacy?.name ??
+      tweet.core.user_results.result.core?.name ??
+      '',
   },
   index: {
     description: 'The media index in tweet (start from 0)',
@@ -90,9 +96,10 @@ export function extractMedia(
 
     // For users, download their profile images and banners.
     if (item.__typename === 'User') {
+      const screenName = item.legacy.screen_name ?? item.core?.screen_name ?? 'unknown';
       if (item.legacy.profile_image_url_https) {
         const ext = getFileExtensionFromUrl(item.legacy.profile_image_url_https);
-        const filename = `${item.legacy.screen_name}_profile_image.${ext}`;
+        const filename = `${screenName}_profile_image.${ext}`;
         gallery.set(filename, {
           filename,
           type: 'photo',
@@ -102,7 +109,7 @@ export function extractMedia(
 
       if (item.legacy.profile_banner_url) {
         const ext = getFileExtensionFromUrl(item.legacy.profile_banner_url);
-        const filename = `${item.legacy.screen_name}_profile_banner.${ext}`;
+        const filename = `${screenName}_profile_banner.${ext}`;
         gallery.set(filename, {
           filename,
           type: 'photo',


### PR DESCRIPTION
## Summary
- support new `core` username/name fields returned by Twitter
- load fallback values when storing user records
- show username/profile name with fallback in tables
- update patterns and URLs to use new fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f5fe3b3d88333ab5de8efac01e444