### PR TITLE
Fix README install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 ## Installation
 
 1. Install the browser extension [Tampermonkey](https://www.tampermonkey.net/) or [Violentmonkey](https://violentmonkey.github.io/)
-2. Click [HERE](https://github.com/prinsss/twitter-web-exporter/releases/latest/download/twitter-web-exporter.user.js) to install the user script
+2. Click [HERE](https://github.com/BM211990/twitter-web-exporter/releases/latest/download/twitter-web-exporter.user.js) to install the user script
 
 ## Usage
 

--- a/docs/README.zh-Hans.md
+++ b/docs/README.zh-Hans.md
@@ -42,7 +42,7 @@
 ## 安装
 
 1. 安装浏览器扩展 [Tampermonkey](https://www.tampermonkey.net/) 或 [Violentmonkey](https://violentmonkey.github.io/)
-2. 点击 [这里](https://github.com/prinsss/twitter-web-exporter/releases/latest/download/twitter-web-exporter.user.js) 安装用户脚本
+2. 点击 [这里](https://github.com/BM211990/twitter-web-exporter/releases/latest/download/twitter-web-exporter.user.js) 安装用户脚本
 
 ## 使用方法
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,15 +52,15 @@ export default defineConfig({
           'zh-TW': '從 Twitter(X) 網頁版匯出推文、書籤、列表等各種資料，支援匯出 JSON/CSV/HTML。',
           ja: 'Twitter(X) ブラウザ版からツイート、ブックマーク、リストなどを取得し JSON/CSV/HTML に出力します。',
         },
-        namespace: 'https://github.com/prinsss',
+        namespace: 'https://github.com/BM211990',
         icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABmklEQVR4Ae3XA4wcARSA4dq2bUQ1g9pRbVtBzai2otpug9pxUttn2753/3m9Ozq/5NsdvvfGM6VKoshE8/ORFbAMbxCGWHzDHjS2sXxPlM0eKYclGoq3w1eIHVGYikaYg6e4ZppgAgQrVBSvDw+IEylIhSAATUyTHIYgFdsUNnAGosAfDMccLMtOchli4g7quFC8FhIhCsRD8Bk1sxMdgVjwxRyUdtDABIgKH9DQNNEkiB1fMB9VbDSwEKLQJ1S1TFQRXhAHYnADy9ETdTEeotAze7tzNJIhCiRBFLpnq/hmzMR65UkVO2WrgaOQPLLW3u6XPDLAVgOl8R5isEhUtHcSdkEoxEBXnN3ZuuMbxCDDnTVQF52xBcEQHX1BaWcNtDLwMpzg6tNtN0RnD5U8XsviGkQnYWih9CWjNBbDHaJBMsZqec8rjV54B1EoFXO0Fh+DrxCFEjBTTdFy6IvNGu4Hf9FXSdGheAUvjZdgLPajqtp3+jl4jVSIAgHYjRZ6fWC0wSpcwScEQZCMUPzEfezEYJQrVRKFOdIAZGq1QBG8EiYAAAAASUVORK5CYII=',
         match: ['*://twitter.com/*', '*://x.com/*'],
         grant: ['unsafeWindow'],
         'run-at': 'document-start',
         updateURL:
-          'https://github.com/prinsss/twitter-web-exporter/releases/latest/download/twitter-web-exporter.user.js',
+          'https://github.com/BM211990/twitter-web-exporter/releases/latest/download/twitter-web-exporter.user.js',
         downloadURL:
-          'https://github.com/prinsss/twitter-web-exporter/releases/latest/download/twitter-web-exporter.user.js',
+          'https://github.com/BM211990/twitter-web-exporter/releases/latest/download/twitter-web-exporter.user.js',
         require: [
           'https://cdn.jsdelivr.net/npm/dayjs@1.11.13/dayjs.min.js',
           'https://cdn.jsdelivr.net/npm/dexie@4.0.11/dist/dexie.min.js',


### PR DESCRIPTION
## Summary
- update README install links to use `BM211990` repo
- keep docs README.zh-Hans in sync
- update monkey user-script updateURL and downloadURL

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f6f0839e483338bc4a96ce1889df3